### PR TITLE
Fix for monolog 3+

### DIFF
--- a/src/ITelmenko/Logger/Monolog/Handler/MysqlHandler.php
+++ b/src/ITelmenko/Logger/Monolog/Handler/MysqlHandler.php
@@ -7,7 +7,11 @@ use ITelmenko\Logger\Laravel\Models\Log;
 
 class MysqlHandler extends AbstractProcessingHandler
 {
-    protected function write(array $record):void
+    /**
+     * @param array|Monolog\LogRecord $record
+     * @return void
+     */
+    protected function write($record): void
     {
         Log::create([
             'instance'    => gethostname(),


### PR DESCRIPTION
Fixed for monolog 3+:
Declaration of ITelmenko\Logger\Monolog\Handler\MysqlHandler::write(array $record): void must be compatible with Monolog\Handler\AbstractProcessingHandler::write(Monolog\LogRecord $record): void